### PR TITLE
Restore support for OpenSSL 1.0.1

### DIFF
--- a/danessl.c
+++ b/danessl.c
@@ -41,6 +41,11 @@
 typedef int CRYPTO_ONCE;
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x1000200fL
+#define SSL_is_server(x) (x->server)
+#define SSL_get0_param(x) (x->param)
+#endif
+
 #include "danessl.h"
 
 #define DANESSL_F_ADD_SKID		100


### PR DESCRIPTION
dane_ssl would not build with OpenSSL 1.0.1

Fixes #2 