### PR TITLE
Fixed compilation on Windows; added DANESSL_add_host

### DIFF
--- a/danessl.h
+++ b/danessl.h
@@ -41,6 +41,7 @@ extern int DANESSL_init(SSL *, const char *, const char **);
 extern void DANESSL_cleanup(SSL *);
 extern int DANESSL_add_tlsa(SSL *, uint8_t, uint8_t, const char *,
 			    unsigned const char *, size_t);
+extern int DANESSL_add_host(SSL *, const char*);
 extern int DANESSL_get_match_cert(SSL *, X509 **, const char **, int *);
 extern int DANESSL_verify_chain(SSL *, STACK_OF(X509) *);
 


### PR DESCRIPTION
Hi Viktor,

Here are some suggested changes that fix compilation on Windows and
add an alternative way to add hosts (reference ids) for DANE-TA verification.

I hope you like them :)

.. Juan